### PR TITLE
add urls when creating new projects

### DIFF
--- a/archive-site-frontend/src/app/create-project/create-project.component.html
+++ b/archive-site-frontend/src/app/create-project/create-project.component.html
@@ -27,6 +27,17 @@
           class="form-control">
       </textarea>
       </label>
+      <label>
+        Document Image URLs <small>
+          <a href="https://github.com/RayBB/GamingTheArchivesSampleData" target="_blank">example</a>
+        </small>
+        <textarea
+          name="urls"
+          [(ngModel)]="urls"
+          class="form-control"
+          placeholder="https://www.example.com/1.jpg&#10;https://www.example.com/2.jpg">
+      </textarea>
+      </label>
     </fieldset>
   </form>
 </div>

--- a/archive-site-frontend/src/app/create-project/create-project.component.ts
+++ b/archive-site-frontend/src/app/create-project/create-project.component.ts
@@ -2,10 +2,11 @@
 //use has been eliminated by the message 
 
 
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { DataApiService } from 'src/app/services/data-api.service';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import Project from 'src/app/models/project';
+import { Document } from 'src/app/models/document';
 import { MessageService } from '../services/message.service';
 
 @Component({
@@ -18,6 +19,7 @@ export class CreateProjectModal implements OnInit {
 
   name: string;
   description?: string;
+  urls?: string;
 
   constructor(
     public activeModal: NgbActiveModal,
@@ -32,8 +34,29 @@ export class CreateProjectModal implements OnInit {
     this.isSaving = true;
     this._dataApi.projectService
       .create(new Project(0, this.name, this.description, 'http://todo/', true))
-      .subscribe((result) => this.activeModal.close(result));
-    this.messageService.add("A new project has been added.")
+      .subscribe(result => {
+        this.createDocumentsFromUrls(result.Id)
+          .then(() => {
+            this.activeModal.close(result);
+          });
+      });
+    this.messageService.add('A new project has been added.');
   }
 
+  createDocumentsFromUrls(projectId: number): Promise<any> {
+    const promises = [];
+    this.urls.split('\n')
+    .forEach(url => {
+      url = url.trim();
+      // This is to avoid empty strings or a stray character added
+      if (url.length > 5) {
+        promises.push(this.createDocumentFromUrl(projectId, url));
+      }
+    });
+    return Promise.all(promises);
+  }
+
+  createDocumentFromUrl(projectId: number, url: string): Promise<any> {
+    return this._dataApi.documentService.create(new Document(0, projectId, 'na', url)).toPromise();
+  }
 }

--- a/archive-site-frontend/src/app/models/document.ts
+++ b/archive-site-frontend/src/app/models/document.ts
@@ -1,7 +1,12 @@
-export interface Document {
-    Id: number,
-    ProjectId: number,
-    FileName: string,
-    DocumentImageUrl: string,
-    Status: string,
+import Model from './model'
+
+export class Document extends Model {
+    constructor(
+        id: number = 0,
+        public ProjectId: number = undefined,
+        public FileName: string = undefined,
+        public DocumentImageUrl: string = undefined,
+        public Status: string = "PendingTranscription") {
+        super(id);
+      }
 }


### PR DESCRIPTION
When creating a project you can paste in a list of urls and documents will be created alongside that project with the given urls.

This is just to avoid dealing with image hosting until a later date.

GUI now looks like this:
![image](https://user-images.githubusercontent.com/921217/98483492-f5641300-21ac-11eb-8731-db9092f79837.png)
